### PR TITLE
Add from_timestamp_micros function

### DIFF
--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -17,7 +17,7 @@ fn test_datetime_from_timestamp_millis() {
         (2034061609000, "2034-06-16 09:06:49.000000000"),
     ];
 
-    for (timestamp_millis, formatted) in valid_map.iter().cloned() {
+    for (timestamp_millis, formatted) in valid_map.iter().copied() {
         let naive_datetime = NaiveDateTime::from_timestamp_millis(timestamp_millis);
         assert_eq!(timestamp_millis, naive_datetime.unwrap().timestamp_millis());
         assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), formatted);
@@ -25,9 +25,46 @@ fn test_datetime_from_timestamp_millis() {
 
     let invalid = [i64::MAX, i64::MIN];
 
-    for timestamp_millis in invalid.iter().cloned() {
+    for timestamp_millis in invalid.iter().copied() {
         let naive_datetime = NaiveDateTime::from_timestamp_millis(timestamp_millis);
         assert!(naive_datetime.is_none());
+    }
+}
+
+#[test]
+fn test_datetime_from_timestamp_micros() {
+    let valid_map = [
+        (1662921288000000, "2022-09-11 18:34:48.000000000"),
+        (1662921288123456, "2022-09-11 18:34:48.123456000"),
+        (1662921287890000, "2022-09-11 18:34:47.890000000"),
+        (-2208936075000000, "1900-01-01 14:38:45.000000000"),
+        (0, "1970-01-01 00:00:00.000000000"),
+        (119731017000000, "1973-10-17 18:36:57.000000000"),
+        (1234567890000000, "2009-02-13 23:31:30.000000000"),
+        (2034061609000000, "2034-06-16 09:06:49.000000000"),
+    ];
+
+    for (timestamp_micros, formatted) in valid_map.iter().copied() {
+        let naive_datetime = NaiveDateTime::from_timestamp_micros(timestamp_micros);
+        assert_eq!(timestamp_micros, naive_datetime.unwrap().timestamp_micros());
+        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), formatted);
+    }
+
+    let invalid = [i64::MAX, i64::MIN];
+
+    for timestamp_micros in invalid.iter().copied() {
+        let naive_datetime = NaiveDateTime::from_timestamp_micros(timestamp_micros);
+        assert!(naive_datetime.is_none());
+    }
+
+    // Test that the result of `from_timestamp_micros` compares equal to
+    // that of `from_timestamp_opt`.
+    let secs_test = [0, 1, 2, 1000, 1234, 12345678, -1, -2, -1000, -12345678];
+    for secs in secs_test.iter().copied() {
+        assert_eq!(
+            NaiveDateTime::from_timestamp_micros(secs * 1_000_000),
+            NaiveDateTime::from_timestamp_opt(secs, 0)
+        );
     }
 }
 


### PR DESCRIPTION
This is our fork of Chrono. We would like to depend on this in Materialize in order to get rid of the similar copy-and-pasted code added [here](https://github.com/MaterializeInc/materialize/pull/16609)

PR'ed upstream [here](https://github.com/chronotope/chrono/pull/906).

Once this is accepted, I will change Materialize to depend on this fork.

If the Chrono folks accept my PR, we can switch to depending on the v0.4.x HEAD of their repo, rather than using this fork.